### PR TITLE
[_]: feat/placeholder-mark-as-sync

### DIFF
--- a/include/placeholders_interface/Placeholders.h
+++ b/include/placeholders_interface/Placeholders.h
@@ -25,4 +25,6 @@ public:
         FILETIME lastWriteTime,
         FILETIME lastAccessTime,
         _In_ PCWSTR destPath);
+
+    static void MarkItemAsSync(const std::wstring &filePath, bool isDirectory);
 };

--- a/include/sync_root_watcher/DirectoryWatcher.h
+++ b/include/sync_root_watcher/DirectoryWatcher.h
@@ -2,29 +2,33 @@
 
 #include <node_api.h>
 
-enum ChangeType {
+enum ChangeType
+{
     NEW_FILE,
     NEW_FOLDER,
     MODIFIED_FILE
 };
-struct FileChange {
+struct FileChange
+{
     std::wstring path;
     bool item_added;
     ChangeType type;
 };
 
-struct InputCallbacks {
+struct InputCallbacks
+{
     napi_ref notify_file_added_callback_ref;
 };
 
-struct InputSyncCallbacksThreadsafe {
+struct InputSyncCallbacksThreadsafe
+{
     napi_threadsafe_function notify_file_added_threadsafe_callback;
 };
 class DirectoryWatcher
 {
 public:
     std::atomic<bool> _shouldRun;
-    void Initialize(_In_ PCWSTR path, _In_ std::function<void(std::list<FileChange>&, napi_env env, InputSyncCallbacksThreadsafe input)> callback, napi_env env, InputSyncCallbacksThreadsafe input);
+    void Initialize(_In_ PCWSTR path, _In_ std::function<void(std::list<FileChange> &, napi_env env, InputSyncCallbacksThreadsafe input)> callback, napi_env env, InputSyncCallbacksThreadsafe input);
     winrt::Windows::Foundation::IAsyncAction ReadChangesAsync();
     void Cancel();
 
@@ -38,6 +42,5 @@ private:
     std::unique_ptr<FILE_NOTIFY_INFORMATION> _notify;
     OVERLAPPED _overlapped{};
     winrt::Windows::Foundation::IAsyncAction _readTask;
-    std::function<void(std::list<FileChange>&, napi_env env, InputSyncCallbacksThreadsafe input)> _callback;
+    std::function<void(std::list<FileChange> &, napi_env env, InputSyncCallbacksThreadsafe input)> _callback;
 };
-


### PR DESCRIPTION
what:
- added the function mark item as sync to become a folder placeholder as sync placeholder

why:
- because when a folder was created as placeholder the placehodler needs to be item sync  to work with callbacks