### PR TITLE
[_]: fix/remove unlink function from unregister sync root

### DIFF
--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -215,7 +215,6 @@ class VirtualDrive {
 
     static unregisterSyncRoot(syncRootPath: string): any {
         const result = addon.unregisterSyncRoot(syncRootPath);
-        deleteAllSubfolders(syncRootPath);
         return result;
     }
 


### PR DESCRIPTION
why: avoid removing files that probably haven't finished loading