### PR TITLE
[_]: fix/check-size-added-item

### DIFF
--- a/examples/register.ts
+++ b/examples/register.ts
@@ -115,7 +115,22 @@ async function onCancelFetchDataCallback(fileId: string) {
     console.log("cancel fetch data: ", fileId);
 }
 
-const iconPath = 'C:\\Users\\gcarl\\Downloads\\sicon.ico';
+async function onMessageCallback(
+    message: string, 
+    action: string, 
+    errorName: string, 
+    callback: (response: boolean) => void) {
+    try {
+        console.log("[Example] Message received: ", message);
+        console.log("[Example] Action: ", action);
+        console.log("[Example] Error name: ", errorName);
+        await callback(true);
+    } catch (error) {
+        callback(false);
+    }
+}
+
+const iconPath = 'C:\\Users\\User\\Downloads\\sicon.ico';
 drive.registerSyncRoot(
     config.driveName,
     config.driveVersion,
@@ -125,7 +140,9 @@ drive.registerSyncRoot(
         notifyRenameCallback: onRenameCallbackWithCallback,
         notifyFileAddedCallback: onFileAddedCallback,
         fetchDataCallback: onFetchDataCallback,
-        cancelFetchDataCallback: onCancelFetchDataCallback
+        cancelFetchDataCallback: onCancelFetchDataCallback,
+        notifyMessageCallback: onMessageCallback,
+
     },
     iconPath
 )
@@ -168,14 +185,10 @@ drive.createFolderByPath(`/folderWithFolder/F.O.L.D.E.R`, 'fa8217c9-2dd6-4641-91
 drive.createItemByPath(`/item-folder/`, 'fa8217c9-2dd6-4641-9189-8206e60368123', 1000, folderCreatedAt, folderUpdatedAt);
 drive.createItemByPath(`/imagen-item.rar`, 'fa8217c9-2dd6-4641-9180-053fe60368f1', 33020, fileCreatedAt, fileUpdatedAt);
 
-// // get items --------------
-// console.log('\n==============    GET ITEMS IDS    ==============');
-// drive.getItemsIds().then((ids) => {
-//     ids.map((id,i) => {
-//         console.log(`Item Id [${i}]: ` + id);
-//     })
-// })
-// //---------------
+// get items --------------
+console.log('\n==============    GET ITEMS IDS    ==============');
+// drive.getItemsIds();
+//---------------
 
 
 // using the watch and wait method

--- a/include/sync_root_interface/Utilities.h
+++ b/include/sync_root_interface/Utilities.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Windows.h>
+#include "ProcessTypes.h"
 class Utilities
 {
 public:
@@ -7,9 +8,11 @@ public:
     static void ApplyTransferStateToFile(_In_ LPCWSTR fullPath, _In_ CF_CALLBACK_INFO &callbackInfo, UINT64 total, UINT64 completed);
     static void ApplyCustomStateToPlaceholderFile(_In_ LPCWSTR path, _In_ LPCWSTR filename, _In_ winrt::StorageProviderItemProperty &prop);
     static void ApplyCustomOverwriteStateToPlaceholderFile(_In_ LPCWSTR path, _In_ LPCWSTR filename, _In_ winrt::StorageProviderItemProperty &prop);
+    static std::wstring ProcessErrorNameToWString(_In_ ProcessErrorName error);
+    static std::wstring FileOperationErrorToWString(_In_ FileOperationError error);
 
-
-    static winrt::com_array<wchar_t> ConvertSidToStringSid(_In_ PSID sid)
+    static winrt::com_array<wchar_t>
+    ConvertSidToStringSid(_In_ PSID sid)
     {
         winrt::com_array<wchar_t> string;
         if (::ConvertSidToStringSidW(sid, winrt::put_abi(string)))

--- a/include/sync_root_interface/callbacks/Callbacks.h
+++ b/include/sync_root_interface/callbacks/Callbacks.h
@@ -27,4 +27,8 @@ void CALLBACK cancel_fetch_data_callback_wrapper(_In_ CONST CF_CALLBACK_INFO *ca
 
 // Notify File Added Callback. This is a fake callback
 void notify_file_added_call(napi_env env, napi_value js_callback, void *context, void *data);
-void register_threadsafe_notify_file_added_callback(FileChange& change, const std::string &resource_name, napi_env env, InputSyncCallbacksThreadsafe input);
+void register_threadsafe_notify_file_added_callback(FileChange &change, const std::string &resource_name, napi_env env, InputSyncCallbacksThreadsafe input);
+
+// Notify message from node-win
+void notify_message_call(napi_env env, napi_value js_callback, void *context, void *data);
+void register_threadsafe_message_callback(FileChange &change, const std::string &resource_name, napi_env env, InputSyncCallbacksThreadsafe input);

--- a/include/sync_root_watcher/DirectoryWatcher.h
+++ b/include/sync_root_watcher/DirectoryWatcher.h
@@ -2,6 +2,9 @@
 
 #include <node_api.h>
 
+// 20GB limit
+#define FILE_SIZE_LIMIT 21474836480
+
 enum ChangeType
 {
     NEW_FILE,
@@ -16,16 +19,19 @@ struct FileChange
     std::wstring path;
     bool item_added;
     ChangeType type;
+    std::wstring message;
 };
 
 struct InputCallbacks
 {
     napi_ref notify_file_added_callback_ref;
+    napi_ref notify_message_callback_ref;
 };
 
 struct InputSyncCallbacksThreadsafe
 {
     napi_threadsafe_function notify_file_added_threadsafe_callback;
+    napi_threadsafe_function notify_message_threadsafe_callback;
 };
 class DirectoryWatcher
 {

--- a/include/types/ProcessTypes.h
+++ b/include/types/ProcessTypes.h
@@ -1,0 +1,22 @@
+#pragma once
+
+enum class ProcessErrorName
+{
+    NOT_EXISTS,
+    NO_PERMISSION,
+    NO_INTERNET,
+    NO_REMOTE_CONNECTION,
+    BAD_RESPONSE,
+    EMPTY_FILE,
+    FILE_TOO_BIG,
+    UNKNOWN
+};
+
+enum class FileOperationError
+{
+    UPLOAD_ERROR,
+    DOWNLOAD_ERROR,
+    RENAME_ERROR,
+    DELETE_ERROR,
+    METADATA_READ_ERROR
+};

--- a/native-src/sync_root_interface/Utilities.cpp
+++ b/native-src/sync_root_interface/Utilities.cpp
@@ -3,6 +3,7 @@
 #include <propkey.h>
 #include <propvarutil.h>
 #include "Utilities.h"
+#include <ProcessTypes.h>
 
 #define MSSEARCH_INDEX L"SystemIndex"
 DEFINE_PROPERTYKEY(PKEY_StorageProviderTransferProgress, 0xE77E90DF, 0x6271, 0x4F5B, 0x83, 0x4F, 0x2D, 0xD1, 0xF2, 0x45, 0xDD, 0xA4, 4);
@@ -52,7 +53,6 @@ void Utilities::ApplyCustomOverwriteStateToPlaceholderFile(LPCWSTR path, LPCWSTR
     }
 }
 
-
 void Utilities::AddFolderToSearchIndexer(_In_ PCWSTR folder)
 {
     HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
@@ -91,13 +91,12 @@ void Utilities::ApplyTransferStateToFile(_In_ PCWSTR fullPath, _In_ CF_CALLBACK_
 {
     printf("ApplyTransferStateToFile\n");
     // Tell the Cloud File API about progress so that toasts can be displayed
- 
+
     HRESULT hr1 = CfReportProviderProgress(
-            callbackInfo.ConnectionKey,
-            callbackInfo.TransferKey,
-            LongLongToLargeInteger(total),
-            LongLongToLargeInteger(completed)
-        );
+        callbackInfo.ConnectionKey,
+        callbackInfo.TransferKey,
+        LongLongToLargeInteger(total),
+        LongLongToLargeInteger(completed));
 
     if (FAILED(hr1))
     {
@@ -156,5 +155,49 @@ void Utilities::ApplyTransferStateToFile(_In_ PCWSTR fullPath, _In_ CF_CALLBACK_
         // winrt::to_hresult() will eat the exception if it is a result of winrt::check_hresult,
         // otherwise the exception will get rethrown and this method will crash out as it should
         wprintf(L"Failed to Set Transfer Progress on \"%s\" with %08x\n", fullPath, static_cast<HRESULT>(winrt::to_hresult()));
+    }
+}
+
+std::wstring Utilities::ProcessErrorNameToWString(ProcessErrorName error)
+{
+    switch (error)
+    {
+    case ProcessErrorName::NOT_EXISTS:
+        return L"NOT_EXISTS";
+    case ProcessErrorName::NO_PERMISSION:
+        return L"NO_PERMISSION";
+    case ProcessErrorName::NO_INTERNET:
+        return L"NO_INTERNET";
+    case ProcessErrorName::NO_REMOTE_CONNECTION:
+        return L"NO_REMOTE_CONNECTION";
+    case ProcessErrorName::BAD_RESPONSE:
+        return L"BAD_RESPONSE";
+    case ProcessErrorName::EMPTY_FILE:
+        return L"EMPTY_FILE";
+    case ProcessErrorName::FILE_TOO_BIG:
+        return L"FILE_TOO_BIG";
+    case ProcessErrorName::UNKNOWN:
+        return L"UNKNOWN";
+    default:
+        return L"UNKNOWN";
+    }
+}
+
+std::wstring Utilities::FileOperationErrorToWString(FileOperationError error)
+{
+    switch (error)
+    {
+    case FileOperationError::UPLOAD_ERROR:
+        return L"UPLOAD_ERROR";
+    case FileOperationError::DOWNLOAD_ERROR:
+        return L"DOWNLOAD_ERROR";
+    case FileOperationError::RENAME_ERROR:
+        return L"RENAME_ERROR";
+    case FileOperationError::DELETE_ERROR:
+        return L"DELETE_ERROR";
+    case FileOperationError::METADATA_READ_ERROR:
+        return L"METADATA_READ_ERROR";
+    default:
+        return L"UNKNOWN";
     }
 }

--- a/native-src/sync_root_interface/callbacks/NotifyMessage/NofifyMessageCallback.cpp
+++ b/native-src/sync_root_interface/callbacks/NotifyMessage/NofifyMessageCallback.cpp
@@ -1,0 +1,136 @@
+#include "Callbacks.h"
+#include "DirectoryWatcher.h"
+#include "Utilities.h"
+#include "ProcessTypes.h"
+
+inline std::mutex mtx;
+inline std::condition_variable cv;
+inline bool ready = false;
+inline bool callbackResult = false;
+inline std::wstring server_identity;
+#include <filesystem>
+
+struct ProcessNotifications
+{
+    std::wstring message;
+    std::wstring action;
+    std::wstring errorName;
+};
+
+napi_value response_callback_fn_nofify(napi_env env, napi_callback_info info)
+{
+    wprintf(L"[Log] notify callback called\n");
+    // just 1 argument
+    size_t argc = 1;
+    napi_value argv[1];
+    napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr);
+
+    if (argc < 1)
+    {
+        wprintf(L"[Error] This function must receive at least two arguments");
+        return nullptr;
+    }
+    napi_valuetype valueType;
+
+    // Verificar el primer argumento: debería ser un booleano
+    napi_typeof(env, argv[0], &valueType);
+    if (valueType != napi_boolean)
+    {
+        wprintf(L"[Error] First argument should be boolean\n");
+        return nullptr;
+    }
+    bool confirmation_response;
+    napi_get_value_bool(env, argv[0], &confirmation_response);
+
+    std::lock_guard<std::mutex> lock(mtx);
+    ready = true;
+    callbackResult = confirmation_response;
+
+    cv.notify_one();
+
+    return nullptr;
+}
+
+void notify_message_call(napi_env env, napi_value js_callback, void *context, void *data)
+{
+    napi_status status;
+    // std::wstring *receivedData = static_cast<std::wstring *>(data);
+    ProcessNotifications *args = static_cast<ProcessNotifications *>(data);
+    napi_value js_message, js_action, js_errorName, js_response_callback_fn, undefined, result;
+    // asign data to the js_string
+    std::u16string u16_action(args->action.begin(), args->action.end());
+    std::u16string u16_errorName(args->errorName.begin(), args->errorName.end());
+    std::u16string u16_message(args->message.begin(), args->message.end());
+    // napi_create_string_utf16(env, reinterpret_cast<const char16_t *>(receivedData->c_str()), receivedData->size(), &js_string1);
+
+    status = napi_create_string_utf16(env, u16_action.c_str(), u16_action.size(), &js_action);
+    if (status != napi_ok)
+    {
+        fprintf(stderr, "[Error] Failed to create u16_action string.\n");
+        return;
+    }
+
+    status = napi_create_string_utf16(env, u16_errorName.c_str(), u16_errorName.size(), &js_errorName);
+    if (status != napi_ok)
+    {
+        fprintf(stderr, "[Error] Failed to create u16_errorName string.\n");
+        return;
+    }
+
+    status = napi_create_string_utf16(env, u16_message.c_str(), u16_message.size(), &js_message);
+    if (status != napi_ok)
+    {
+        fprintf(stderr, "[Error] Failed to create u16_message string.\n");
+        return;
+    }
+
+    // asign the nofify callback function to the js_response_callback_fn
+    napi_create_function(env, "responseCallback", NAPI_AUTO_LENGTH, response_callback_fn_nofify, nullptr, &js_response_callback_fn);
+
+    napi_value args_to_js_callback[4] = {js_message, js_action, js_errorName, js_response_callback_fn};
+    status = napi_get_undefined(env, &undefined);
+    if (status != napi_ok)
+    {
+        fprintf(stderr, "[Error] Failed to get undefined value.\n");
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        ready = false;
+    }
+
+    status = napi_call_function(env, undefined, js_callback, 4, args_to_js_callback, &result);
+    if (status != napi_ok)
+    {
+        fprintf(stderr, "[Error] Failed to call JS function.\n");
+        return;
+    }
+    delete args;
+}
+
+void register_threadsafe_message_callback(FileChange &change, const std::string &resource_name, napi_env env, InputSyncCallbacksThreadsafe input)
+{
+    ProcessNotifications *args = new ProcessNotifications();
+    switch (change.type)
+    {
+    case ERROR_FILE_SIZE_EXCEEDED:
+        args->action = Utilities::FileOperationErrorToWString(FileOperationError::UPLOAD_ERROR);
+        args->errorName = Utilities::ProcessErrorNameToWString(ProcessErrorName::FILE_TOO_BIG);
+        args->message = change.message;
+        break;
+    default:
+        break;
+    }
+
+    napi_status status = napi_call_threadsafe_function(input.notify_message_threadsafe_callback, args, napi_tsfn_blocking);
+
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        while (!ready)
+        {
+            cv.wait(lock);
+        }
+    }
+    wprintf(L"[Debug] notify message was received: %d\n", callbackResult);
+};

--- a/native-src/sync_root_watcher/DirectoryWatcher.cpp
+++ b/native-src/sync_root_watcher/DirectoryWatcher.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 
 const size_t c_bufferSize = 32768; // sizeof(FILE_NOTIFY_INFORMATION) * 100;
+
 namespace fs = std::filesystem;
 
 bool IsTemporaryFile(const std::wstring &fullPath)
@@ -182,17 +183,16 @@ winrt::Windows::Foundation::IAsyncAction DirectoryWatcher::ReadChangesInternalAs
 
             if ((next->Action == FILE_ACTION_ADDED || (next->Action == FILE_ACTION_MODIFIED && !fileExists)) && !isTmpFile && !isDirectory && !isHidden)
             {
-                wprintf(L"\nnew file: %s\n", fullPath.c_str());
+                wprintf(L"\n[Log] New file: %s\n", fullPath.c_str());
                 std::filesystem::path p(fullPath);
-                // si es mayor a 20GB emitir error
-                if (std::filesystem::file_size(p) > 20000000000)
+
+                if (std::filesystem::file_size(p) > FILE_SIZE_LIMIT)
                 {
                     fc.type = ERROR_FILE_SIZE_EXCEEDED;
                     fc.item_added = false;
                     result.push_back(fc);
                     break;
                 }
-                // size del archivo
 
                 fc.type = NEW_FILE;
                 fc.item_added = true;
@@ -200,18 +200,7 @@ winrt::Windows::Foundation::IAsyncAction DirectoryWatcher::ReadChangesInternalAs
             }
             else if (next->Action == FILE_ACTION_ADDED && isDirectory && !isHidden)
             {
-                // if (getDirectorySize(fullPath) > 20000000000)
-                // {
-                //     fc.type = ERROR_FOLDER_SIZE_EXCEEDED;
-                //     fc.item_added = false;
-                //     result.push_back(fc);
-                //     break;
-                // }
-                // else
-                // {
-
                 ExploreDirectory(fullPath, result, fc);
-                // }
             }
             else
             {

--- a/native-src/sync_root_watcher/SyncRootWatcher.cpp
+++ b/native-src/sync_root_watcher/SyncRootWatcher.cpp
@@ -72,22 +72,16 @@ void SyncRootWatcher::OnSyncRootFileChanges(_In_ std::list<FileChange> &changes,
 
     for (auto change : changes)
     {
-        wprintf(L"Processing change for %s\n", change.path.c_str());
+        wprintf(L"[Log] Processing change for %s\n", change.path.c_str());
 
         if (change.type == ERROR_FILE_SIZE_EXCEEDED || change.type == ERROR_FOLDER_SIZE_EXCEEDED)
         {
-            wprintf(L"Error processing change for %s\n", change.path.c_str());
-            // generar un backup del archivo o carpeta que no se pudo procesar
+            wprintf(L"[Error] processing change for %s\n", change.path.c_str());
             if (ERROR_FILE_SIZE_EXCEEDED)
             {
-                wprintf(L"ERROR_FILE_SIZE_EXCEEDED\n");
-                // TODO: generate a callback to notify the error
-            }
-            else if (ERROR_FOLDER_SIZE_EXCEEDED)
-            {
-                // TODO: check it if this is a use case to keep in mind
-                wprintf(L"ERROR_FOLDER_SIZE_EXCEEDED\n");
-                // TODO: generate a callback to notify the error
+                wprintf(L"[Log] ERROR_FILE_SIZE_EXCEEDED\n");
+                change.message = change.path.c_str();
+                register_threadsafe_message_callback(change, "message", env, input);
             }
             break;
         }
@@ -105,12 +99,12 @@ void SyncRootWatcher::OnSyncRootFileChanges(_In_ std::list<FileChange> &changes,
 
             if (attrib & FILE_ATTRIBUTE_PINNED)
             {
-                wprintf(L"Hydrating file %s\n", change.path.c_str());
+                wprintf(L"[Log] Hydrating file %s\n", change.path.c_str());
                 CfHydratePlaceholder(placeholder.get(), offset, length, CF_HYDRATE_FLAG_NONE, NULL);
             }
             else if (attrib & FILE_ATTRIBUTE_UNPINNED)
             {
-                wprintf(L"Dehydrating file %s\n", change.path.c_str());
+                wprintf(L"[Log] Dehydrating file %s\n", change.path.c_str());
                 CfDehydratePlaceholder(placeholder.get(), offset, length, CF_DEHYDRATE_FLAG_NONE, NULL);
             }
         }

--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -36,6 +36,7 @@ type InputSyncCallbacks = {
 
 type ExtraCallbacks = {
     notifyFileAddedCallback?: NapiCallbackFunction;
+    notifyMessageCallback?: NapiCallbackFunction;
 }
 
 type Callbacks = InputSyncCallbacks & ExtraCallbacks;
@@ -92,7 +93,8 @@ class VirtualDrive {
 
     getExtraCallbacks(): ExtraCallbacks {
         const extraCallbackKeys: (keyof ExtraCallbacks)[] = [
-            'notifyFileAddedCallback'
+            'notifyFileAddedCallback',
+            'notifyMessageCallback',
         ];
 
         const result: ExtraCallbacks = {};


### PR DESCRIPTION
should be merged to use from [client](https://github.com/internxt/drive-desktop/pull/419)

What:
- We need a callback in the folder root's watch and wait to report errors when loading files of unacceptable size and to display notifications from the desktop app.

Why: 
- The error notifications should be done from the client.

![image](https://github.com/internxt/node-win/assets/92745882/7895b8cd-20f3-4058-966f-ad595d173754)
