### PR TITLE
[_]: feat/sync clean after unregister

### DIFF
--- a/examples/unregister.ts
+++ b/examples/unregister.ts
@@ -5,4 +5,18 @@ import VirtualDrive from '../src/virtual-drive';
 import * as config from './config.json';
 
 VirtualDrive.unregisterSyncRoot(config.syncRootPath);
-// VirtualDrive.SyncAndCleanUp();
+// cloud items to sync
+// should customize this to your own cloud storage test folder
+const cloudItems: string[] =  [
+    "C:\\Users\\User\\Desktop\\carpeta\\ab",
+    "C:\\Users\\User\\Desktop\\carpeta\\file1.txt",
+    "C:\\Users\\User\\Desktop\\carpeta\\folderWithFile",
+    "C:\\Users\\User\\Desktop\\carpeta\\folderWithFile\\file2.txt",
+    "C:\\Users\\User\\Desktop\\carpeta\\A",
+    "C:\\Users\\User\\Desktop\\carpeta\\A\\ab - Copy",
+    "C:\\Users\\User\\Desktop\\carpeta\\A\\ab - Copy - Copy",
+    "C:\\Users\\User\\Desktop\\carpeta\\A\\B",
+    "C:\\Users\\User\\Desktop\\carpeta\\A\\B\\ab - Copy - Copy",
+    "C:\\Users\\User\\Desktop\\carpeta\\A\\B\\C",
+  ];
+VirtualDrive.syncAndCleanUp(config.syncRootPath, cloudItems);

--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -366,8 +366,8 @@ class VirtualDrive {
         return addon.disconnectSyncRoot(this.syncRootPath);
     }
 
-    syncAndCleanUp(): any {
-        
+    static syncAndCleanUp(syncRootPath: string, items: string[]): any {
+        return deleteAllSubfolders(syncRootPath, { filtered: true, filterPaths: items });
     }    
 }
 


### PR DESCRIPTION
update:
- function to sync betwent cloud items and items not removed by unregister then cleanup

why:
- after unregister we should compare and cleanup synchronized items on virtual drive instead of remove everything
