### PR TITLE
Update OnSyncRootFileChanges

### DIFF
--- a/native-src/sync_root_watcher/SyncRootWatcher.cpp
+++ b/native-src/sync_root_watcher/SyncRootWatcher.cpp
@@ -98,6 +98,7 @@ void SyncRootWatcher::OnSyncRootFileChanges(_In_ std::list<FileChange> &changes,
 
                 if (attrib & FILE_ATTRIBUTE_PINNED)
                 {
+                     Sleep(500);
                     Logger::getInstance().log("Hydrating file" + Logger::fromWStringToString(change.path), LogLevel::INFO);
                     CfHydratePlaceholder(placeholder.get(), offset, length, CF_HYDRATE_FLAG_NONE, NULL);
                 }


### PR DESCRIPTION
**Update**:

A fix has been implemented in the OnSyncRootFileChanges function, involving the addition of a sleep before hydrating the placeholders.

Why:

This adjustment aims to address task overload when handling multiple file loads.

Changes Made:

Strategically added a delay before hydrating placeholders in the OnSyncRootFileChanges function. Reasoning:

The introduction of this delay is crucial to prevent task overload, especially when dealing with the simultaneous loading of multiple files. This change contributes to more efficient resource management and enhances file synchronization.

**Pending:**

Recognizing the need for a more optimal solution, such as exploring threaded execution instead of relying on sleep, to comprehensively address hydration.