### PR TITLE
Move pino to winston

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /dist
 /examples/tmp
 /node_modules
-/node-win.log
 /package-lock.json
 /test-files
 /venv

--- a/examples/callbacks/cancel-fetch-data.callback.ts
+++ b/examples/callbacks/cancel-fetch-data.callback.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/logger";
+import { logger } from "examples/drive";
 
 export const cancelFetchDataCallback = (fileId: string) => {
   logger.info({ event: "cancelFetchDataCallback", fileId });

--- a/examples/callbacks/notify-delete.callback.ts
+++ b/examples/callbacks/notify-delete.callback.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/logger";
+import { logger } from "examples/drive";
 
 export const notifyDeleteCallback = (fileId: string, callback: (response: boolean) => void) => {
   logger.info({ event: "notifyDeleteCallback", fileId });

--- a/examples/callbacks/notify-message.callback.ts
+++ b/examples/callbacks/notify-message.callback.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/logger";
+import { logger } from "examples/drive";
 
 export const notifyMessageCallback = (message: string, action: string, errorName: string, callback: (response: boolean) => void) => {
   logger.info({ event: "notifyMessageCallback", message, action, errorName });

--- a/examples/callbacks/notify-rename.callback.ts
+++ b/examples/callbacks/notify-rename.callback.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/logger";
+import { logger } from "examples/drive";
 
 export const notifyRenameCallback = (newName: string, fileId: string, callback: (response: boolean) => void) => {
   logger.info({ event: "notifyRenameCallback", newName, fileId });

--- a/examples/drive.ts
+++ b/examples/drive.ts
@@ -1,6 +1,7 @@
+import { createLogger } from "@/logger";
 import VirtualDrive from "@/virtual-drive";
 
 import settings from "./settings";
 
 export const drive = new VirtualDrive(settings.syncRootPath, settings.defaultLogPath);
-export const logger = drive.logger;
+export const logger = createLogger(settings.defaultLogPath);

--- a/examples/drive.ts
+++ b/examples/drive.ts
@@ -3,3 +3,4 @@ import VirtualDrive from "@/virtual-drive";
 import settings from "./settings";
 
 export const drive = new VirtualDrive(settings.syncRootPath, settings.defaultLogPath);
+export const logger = drive.logger;

--- a/examples/get-state.ts
+++ b/examples/get-state.ts
@@ -24,5 +24,5 @@ if (data) {
   const pendingStates = drive.getPlaceholderWithStatePending();
   logger.info({ state, pendingStates });
 } else {
-  console.error("Por favor especifica un archivo con --file <path>");
+  logger.error("Por favor especifica un archivo con --file <path>");
 }

--- a/examples/get-state.ts
+++ b/examples/get-state.ts
@@ -1,9 +1,7 @@
 import yargs from "yargs";
 import z from "zod";
 
-import { logger } from "@/logger";
-
-import { drive } from "./drive";
+import { drive, logger } from "./drive";
 
 const argv = yargs
   .command("file", "El path del archivo para obtener el estado", {

--- a/examples/handlers/handle-add.ts
+++ b/examples/handlers/handle-add.ts
@@ -1,9 +1,8 @@
-import { drive } from "examples/drive";
+import { drive, logger } from "examples/drive";
 import { addInfoItem } from "examples/info-items-manager";
-
-import { logger } from "@/logger";
-import { QueueItem } from "@/queue/queueManager";
 import { v4 } from "uuid";
+
+import { QueueItem } from "@/queue/queueManager";
 
 export const handleAdd = async (task: QueueItem) => {
   try {

--- a/examples/handlers/handle-add.ts
+++ b/examples/handlers/handle-add.ts
@@ -11,6 +11,6 @@ export const handleAdd = async (task: QueueItem) => {
     const id = task.isFolder ? v4() : addInfoItem(task.path);
     drive.convertToPlaceholder(task.path, id);
   } catch (error) {
-    logger.error(error, "handleAdd");
+    logger.error("handleAdd", error);
   }
 };

--- a/examples/handlers/handle-change-size.ts
+++ b/examples/handlers/handle-change-size.ts
@@ -11,6 +11,6 @@ export const handleChangeSize = async (task: QueueItem) => {
     drive.updateFileIdentity(task.path, result, false);
     drive.updateSyncStatus(task.path, task.isFolder, true);
   } catch (error) {
-    logger.error(error, "handleChangeSize");
+    logger.error("handleChangeSize", error);
   }
 };

--- a/examples/handlers/handle-change-size.ts
+++ b/examples/handlers/handle-change-size.ts
@@ -1,6 +1,5 @@
-import { drive } from "examples/drive";
+import { drive, logger } from "examples/drive";
 
-import { logger } from "@/logger";
 import { QueueItem } from "@/queue/queueManager";
 
 export const handleChangeSize = async (task: QueueItem) => {

--- a/examples/handlers/handle-dehydrate.ts
+++ b/examples/handlers/handle-dehydrate.ts
@@ -8,6 +8,6 @@ export const handleDehydrate = async (task: QueueItem) => {
     logger.info({ fn: "handleDehydrate", path: task.path });
     drive.dehydrateFile(task.path);
   } catch (error) {
-    logger.error(error, "handleDehydrate");
+    logger.error("handleDehydrate", error);
   }
 };

--- a/examples/handlers/handle-dehydrate.ts
+++ b/examples/handlers/handle-dehydrate.ts
@@ -1,6 +1,5 @@
-import { drive } from "examples/drive";
+import { drive, logger } from "examples/drive";
 
-import { logger } from "@/logger";
 import { QueueItem } from "@/queue/queueManager";
 
 export const handleDehydrate = async (task: QueueItem) => {

--- a/examples/handlers/handle-hydrate.ts
+++ b/examples/handlers/handle-hydrate.ts
@@ -1,6 +1,5 @@
-import { drive } from "examples/drive";
+import { drive, logger } from "examples/drive";
 
-import { logger } from "@/logger";
 import { QueueItem } from "@/queue/queueManager";
 
 export const handleHydrate = async (task: QueueItem) => {

--- a/examples/handlers/handle-hydrate.ts
+++ b/examples/handlers/handle-hydrate.ts
@@ -8,6 +8,6 @@ export const handleHydrate = async (task: QueueItem) => {
     logger.info({ fn: "handleHydrate", path: task.path });
     await drive.hydrateFile(task.path);
   } catch (error) {
-    logger.error(error, "handleHydrate");
+    logger.error("handleHydrate", error);
   }
 };

--- a/examples/register.ts
+++ b/examples/register.ts
@@ -1,4 +1,3 @@
-import { logger } from "@/logger";
 import { QueueManager } from "@/queue/queue-manager";
 import VirtualDrive from "@/virtual-drive";
 
@@ -7,7 +6,7 @@ import { notifyDeleteCallback } from "./callbacks/notify-delete.callback";
 import { fetchDataCallback } from "./callbacks/notify-fetch-data.callback";
 import { notifyMessageCallback } from "./callbacks/notify-message.callback";
 import { notifyRenameCallback } from "./callbacks/notify-rename.callback";
-import { drive } from "./drive";
+import { drive, logger } from "./drive";
 import { handleAdd } from "./handlers/handle-add";
 import { handleChangeSize } from "./handlers/handle-change-size";
 import { handleDehydrate } from "./handlers/handle-dehydrate";

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { QueueManager } from "./src/queue/queue-manager";
-import { IQueueManager, QueueItem, typeQueue, HandleAction, HandleActions } from "./src/queue/queueManager";
+import { QueueItem, typeQueue, HandleAction, HandleActions } from "./src/queue/queueManager";
 import VirtualDrive from "./src/virtual-drive";
 
-export { VirtualDrive, QueueItem, typeQueue, IQueueManager, HandleAction, HandleActions, QueueManager };
+export { VirtualDrive, QueueItem, typeQueue, HandleAction, HandleActions, QueueManager };

--- a/package.json
+++ b/package.json
@@ -48,10 +48,9 @@
     "dependencies": {
         "chokidar": "^3.6.0",
         "lodash.chunk": "^4.2.0",
-        "pino": "^9.6.0",
-        "pino-pretty": "^13.0.0",
         "tsconfig-paths": "^4.2.0",
         "uuid": "^11.0.3",
+        "winston": "^3.17.0",
         "yargs": "^17.7.2",
         "zod": "^3.24.1"
     }

--- a/src/addon/addon-zod.ts
+++ b/src/addon/addon-zod.ts
@@ -25,6 +25,6 @@ export const addonZod = {
 export const parseAddonZod = <T>(fn: keyof typeof addonZod, data: T) => {
   const schema = addonZod[fn];
   const result = schema.safeParse(data);
-  if (result.error) logger.error(result.error, fn);
+  if (result.error) logger.error(fn, result.error);
   return data;
 };

--- a/src/addon/addon-zod.ts
+++ b/src/addon/addon-zod.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import { logger } from "@/logger";
 import { PinState, SyncState } from "@/types/placeholder.type";
 
 export const addonZod = {
@@ -20,11 +19,4 @@ export const addonZod = {
   registerSyncRoot: z.literal(0),
   updateSyncStatus: z.boolean(),
   unregisterSyncRoot: z.number(),
-};
-
-export const parseAddonZod = <T>(fn: keyof typeof addonZod, data: T) => {
-  const schema = addonZod[fn];
-  const result = schema.safeParse(data);
-  if (result.error) logger.error(fn, result.error);
-  return data;
 };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,22 +1,26 @@
 import { resolve } from "path";
 import { inspect } from "util";
-import { createLogger, format, transports } from "winston";
+import winston from "winston";
 
-export const logger = createLogger({
-  format: format.errors({ stack: true }),
-  transports: [
-    new transports.File({
-      filename: resolve("node-win.log"),
-      format: format.combine(format.timestamp(), format.json()),
-    }),
-    new transports.Console({
-      format: format.combine(
-        format.printf(({ level, message, stack }) => {
-          const object: any = { level, message };
-          if (stack) object.stack = stack;
-          return inspect(object, { colors: true, depth: Infinity, breakLength: Infinity });
-        }),
-      ),
-    }),
-  ],
-});
+const { format, transports } = winston;
+
+export const createLogger = (path: string) => {
+  return winston.createLogger({
+    format: format.errors({ stack: true }),
+    transports: [
+      new transports.File({
+        filename: resolve(path),
+        format: format.combine(format.timestamp(), format.json()),
+      }),
+      new transports.Console({
+        format: format.combine(
+          format.printf(({ level, message, stack }) => {
+            const object: any = { level, message };
+            if (stack) object.stack = stack;
+            return inspect(object, { colors: true, depth: Infinity, breakLength: Infinity });
+          }),
+        ),
+      }),
+    ],
+  });
+};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,20 +1,22 @@
-import pino from "pino";
-import { cwd } from "process";
+import { resolve } from "path";
+import { inspect } from "util";
+import { createLogger, format, transports } from "winston";
 
-const transport = pino.transport({
-  targets: [
-    {
-      target: "pino/file",
-      options: { destination: `${cwd()}/node-win.log` },
-    },
-    {
-      target: "pino-pretty",
-      options: {
-        colorize: true,
-        singleLine: true,
-      },
-    },
+export const logger = createLogger({
+  format: format.errors({ stack: true }),
+  transports: [
+    new transports.File({
+      filename: resolve("node-win.log"),
+      format: format.combine(format.timestamp(), format.json()),
+    }),
+    new transports.Console({
+      format: format.combine(
+        format.printf(({ level, message, stack }) => {
+          const object: any = { level, message };
+          if (stack) object.stack = stack;
+          return inspect(object, { colors: true, depth: Infinity, breakLength: Infinity });
+        }),
+      ),
+    }),
   ],
 });
-
-export const logger = pino({}, transport);

--- a/src/queue/queue-manager.ts
+++ b/src/queue/queue-manager.ts
@@ -3,8 +3,6 @@ import lodashChunk from "lodash.chunk";
 
 import { logger } from "@/logger";
 
-// import { logger } from "@/logger";
-
 import { HandleAction, HandleActions, IQueueManager, QueueItem, typeQueue } from "./queueManager";
 
 export type QueueHandler = {

--- a/src/queue/queue-manager.ts
+++ b/src/queue/queue-manager.ts
@@ -1,9 +1,8 @@
 import fs from "fs";
 import lodashChunk from "lodash.chunk";
+import { Logger } from "winston";
 
-import { logger } from "@/logger";
-
-import { HandleAction, HandleActions, IQueueManager, QueueItem, typeQueue } from "./queueManager";
+import { HandleAction, HandleActions, QueueItem, typeQueue } from "./queueManager";
 
 export type QueueHandler = {
   handleAdd: HandleAction;
@@ -18,7 +17,7 @@ export type QueueManagerCallback = {
   onTaskProcessing: () => Promise<void>;
 };
 
-export class QueueManager implements IQueueManager {
+export class QueueManager {
   private queues: { [key: string]: QueueItem[] } = {
     add: [],
     hydrate: [],
@@ -41,6 +40,7 @@ export class QueueManager implements IQueueManager {
   private readonly notify: QueueManagerCallback;
   private readonly persistPath: string;
 
+  logger?: Logger;
   actions: HandleActions;
 
   constructor(handlers: QueueHandler, notify: QueueManagerCallback, persistPath: string) {
@@ -79,7 +79,7 @@ export class QueueManager implements IQueueManager {
   }
 
   private loadQueueStateFromFile(): void {
-    logger.debug("Loading queue state from file:" + this.persistPath);
+    this.logger?.debug("Loading queue state from file:" + this.persistPath);
     if (this.persistPath) {
       if (!fs.existsSync(this.persistPath)) {
         this.saveQueueStateToFile();
@@ -105,11 +105,11 @@ export class QueueManager implements IQueueManager {
   }
 
   public enqueue(task: QueueItem): void {
-    logger.debug({ fn: "enqueue", task });
+    this.logger?.debug({ fn: "enqueue", task });
     const existingTask = this.queues[task.type].find((item) => item.path === task.path && item.type === task.type);
 
     if (existingTask) {
-      logger.info("Task already exists in queue. Skipping.");
+      this.logger?.info("Task already exists in queue. Skipping.");
       return;
     }
 
@@ -181,17 +181,17 @@ export class QueueManager implements IQueueManager {
   }
 
   private async processTask(type: typeQueue, task: QueueItem) {
-    logger.debug({ fn: "processTask", task });
+    this.logger?.debug({ fn: "processTask", task });
 
     try {
       await this.actions[task.type](task);
     } catch (error) {
-      logger.error(`Failed to process ${type} task`, error);
+      this.logger?.error(`Failed to process ${type} task`, error);
     }
   }
 
   public async processAll(): Promise<void> {
-    logger.debug({ fn: "processAll" });
+    this.logger?.debug({ fn: "processAll" });
     const taskTypes = Object.keys(this.queues) as typeQueue[];
     await this.notify.onTaskProcessing();
     await Promise.all(taskTypes.map((type: typeQueue) => this.processQueue(type)));

--- a/src/queue/queueManager.ts
+++ b/src/queue/queueManager.ts
@@ -18,9 +18,3 @@ export type HandleAction = (task: QueueItem) => Promise<void>;
 export type HandleActions = {
   [key in typeQueue]: HandleAction;
 };
-
-export interface IQueueManager {
-  actions: HandleActions;
-
-  enqueue(task: QueueItem): void;
-}

--- a/src/queue/queueManager.ts
+++ b/src/queue/queueManager.ts
@@ -18,3 +18,9 @@ export type HandleAction = (task: QueueItem) => Promise<void>;
 export type HandleActions = {
   [key in typeQueue]: HandleAction;
 };
+
+export interface IQueueManager {
+  actions: HandleActions;
+
+  enqueue(task: QueueItem): void;
+}

--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -7,6 +7,7 @@ import { Status } from "./types/placeholder.type";
 import { IQueueManager } from "./queue/queueManager";
 
 import { addon } from "./addon";
+import { createLogger } from "./logger";
 
 interface ItemInfo {
   path: string;
@@ -247,7 +248,7 @@ class VirtualDrive {
 
     this.watcher.queueManager = queueManager;
 
-    this.watcher.logPath = loggerPath;
+    this.watcher.logger = createLogger(loggerPath);
 
     this.watcher.syncRootPath = path;
     this.watcher.options = {

--- a/src/watcher/detect-context-menu-action.service.ts
+++ b/src/watcher/detect-context-menu-action.service.ts
@@ -59,9 +59,12 @@ export class DetectContextMenuActionService {
       status.pinState == PinState.OnlineOnly &&
       status.syncState == SyncState.InSync
     ) {
-      if (curr.blocks === 0) {
-        return "Liberando espacio";
-      }
+      // TODO: we need to disable this for now even if dehydate it's called two times
+      // because files that are a .zip have blocks === 0, so they never dehydrate
+      // because it's seems that it's already been dehydrated
+      // if (curr.blocks === 0) {
+      //   return "Liberando espacio";
+      // }
 
       self.fileInDevice.delete(path);
       self.queueManager.enqueue({ path, type: typeQueue.dehydrate, isFolder, fileId: itemId });

--- a/src/watcher/detect-context-menu-action.service.ts
+++ b/src/watcher/detect-context-menu-action.service.ts
@@ -14,7 +14,7 @@ export class DetectContextMenuActionService {
     const itemId = self.virtualDriveFn.CfGetPlaceHolderIdentity(path);
     const isInDevice = self.fileInDevice.has(path);
 
-    self.writeLog({
+    self.logger.info({
       event: "onRaw",
       path,
       status,

--- a/src/watcher/events/on-add-dir.service.ts
+++ b/src/watcher/events/on-add-dir.service.ts
@@ -4,6 +4,7 @@ import { typeQueue } from "@/queue/queueManager";
 import { PinState, SyncState } from "@/types/placeholder.type";
 
 import { Watcher } from "../watcher";
+import { logger } from "@/logger";
 
 export class OnAddDirService {
   execute({ self, path, stats }: TProps) {
@@ -20,7 +21,7 @@ export class OnAddDirService {
       self.queueManager.enqueue({ path, type: typeQueue.add, isFolder: true });
     } catch (error) {
       self.writeLog("Error en onAddDir");
-      console.error(error);
+      logger.error("onAddDir",error);
     }
   }
 }

--- a/src/watcher/events/on-add-dir.service.ts
+++ b/src/watcher/events/on-add-dir.service.ts
@@ -4,15 +4,12 @@ import { typeQueue } from "@/queue/queueManager";
 import { PinState, SyncState } from "@/types/placeholder.type";
 
 import { Watcher } from "../watcher";
-import { logger } from "@/logger";
 
 export class OnAddDirService {
-  execute({ self, path, stats }: TProps) {
+  execute({ self, path }: TProps) {
     try {
-      self.writeLog("onAddDir", path, stats);
-
       const status = self.virtualDriveFn.CfGetPlaceHolderState(path);
-      self.writeLog("status", status);
+      self.logger.info({ fn: "onAddDir", path, status });
 
       if (status.pinState === PinState.AlwaysLocal || status.pinState === PinState.OnlineOnly || status.syncState === SyncState.InSync) {
         return;
@@ -20,8 +17,7 @@ export class OnAddDirService {
 
       self.queueManager.enqueue({ path, type: typeQueue.add, isFolder: true });
     } catch (error) {
-      self.writeLog("Error en onAddDir");
-      logger.error("onAddDir",error);
+      self.logger.error("Error en onAddDir", error);
     }
   }
 }

--- a/src/watcher/events/on-add.service.ts
+++ b/src/watcher/events/on-add.service.ts
@@ -4,7 +4,6 @@ import { typeQueue } from "@/queue/queueManager";
 import { PinState, SyncState } from "@/types/placeholder.type";
 
 import { Watcher } from "../watcher";
-import { logger } from "@/logger";
 
 export class OnAddService {
   execute({ self, path, stats }: TProps) {
@@ -13,12 +12,12 @@ export class OnAddService {
       const { size, birthtime, mtime } = stats;
       const fileIntenty = self.virtualDriveFn.CfGetPlaceHolderIdentity(path);
 
-      self.writeLog({ event: "onAdd", path, ext, size, birthtime, mtime, fileIntenty });
+      self.logger.info({ fn: "onAdd", path, ext, size, birthtime, mtime, fileIntenty });
 
       if (!ext || size === 0 || size > 20 * 1024 * 1024 * 1024) return;
 
       const status = self.virtualDriveFn.CfGetPlaceHolderState(path);
-      self.writeLog("status", status);
+      self.logger.info({ fn: "onAdd", path, status });
 
       // Verificar tiempos de creación y modificación
       const creationTime = new Date(birthtime).getTime();
@@ -45,11 +44,11 @@ export class OnAddService {
         self.fileInDevice.add(path);
         self.queueManager.enqueue({ path, type: typeQueue.add, isFolder: false });
       } else if (isMovedFile) {
-        self.writeLog("File moved:", path);
+        self.logger.info({ fn: "onAdd", msg: "File moved", path });
         // Procesar archivo movido según sea necesario
       }
     } catch (error) {
-      logger.error("onAddService", error);
+      self.logger.error("onAddService", error);
     }
   }
 }

--- a/src/watcher/events/on-add.service.ts
+++ b/src/watcher/events/on-add.service.ts
@@ -4,18 +4,16 @@ import { typeQueue } from "@/queue/queueManager";
 import { PinState, SyncState } from "@/types/placeholder.type";
 
 import { Watcher } from "../watcher";
+import { logger } from "@/logger";
 
 export class OnAddService {
   execute({ self, path, stats }: TProps) {
     try {
-      self.writeLog("onAdd", path, stats);
       const ext = path.split(".").pop();
-
       const { size, birthtime, mtime } = stats;
-
       const fileIntenty = self.virtualDriveFn.CfGetPlaceHolderIdentity(path);
 
-      self.writeLog("fileIntenty in add", fileIntenty);
+      self.writeLog({ event: "onAdd", path, ext, size, birthtime, mtime, fileIntenty });
 
       if (!ext || size === 0 || size > 20 * 1024 * 1024 * 1024) return;
 
@@ -51,8 +49,7 @@ export class OnAddService {
         // Procesar archivo movido según sea necesario
       }
     } catch (error) {
-      console.log("Error en onAdd");
-      console.error(error);
+      logger.error("onAddService", error);
     }
   }
 }

--- a/src/watcher/events/on-raw.service.ts
+++ b/src/watcher/events/on-raw.service.ts
@@ -10,26 +10,26 @@ export class OnRawService {
   async execute({ self, event, path, details }: TProps) {
     if (event === "change" && details.prev && details.curr) {
       if (extname(path) === "") {
-        self.writeLog({ event: "onRaw", path, details: "No extension" });
+        self.logger.info({ event: "onRaw", path, details: "No extension" });
         return;
       }
 
       const item = await stat(path);
       if (item.isDirectory()) {
-        self.writeLog({ event: "onRaw", path, details: "Is directory" });
+        self.logger.info({ event: "onRaw", path, details: "Is directory" });
         return;
       }
 
       // // Ignorar archivos vacíos
       // if (item.size === 0) {
-      //   self.writeLog("Archivo vacío ignorado", path);
+      //   self.logger.info("Archivo vacío ignorado", path);
       //   return;
       // }
 
       const action = await this.detectContextMenuAction.execute({ self, details, path, isFolder: false });
 
       if (action) {
-        self.writeLog({ event: "onRaw", path, action });
+        self.logger.info({ event: "onRaw", path, action });
       }
     }
   }

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -2,6 +2,8 @@ import * as chokidar from "chokidar";
 import fs, { Stats } from "fs";
 import { inspect } from "util";
 
+import { logger } from "@/logger";
+
 import { IQueueManager } from "../queue/queueManager";
 import { OnAddDirService } from "./events/on-add-dir.service";
 import { OnAddService } from "./events/on-add.service";
@@ -43,13 +45,15 @@ export class Watcher {
   }
 
   public writeLog = (...messages: unknown[]) => {
+    logger.info(messages);
+
     const date = new Date().toISOString();
     const parsedMessages = inspect(messages, { depth: Infinity });
     const logMessage = `${date} - ${parsedMessages}`;
 
     fs.appendFile(this.logPath, logMessage, (err) => {
       if (err) {
-        console.error("Error writing to log file", err);
+        logger.error("Error writing to log file", err);
       }
     });
   };
@@ -63,7 +67,7 @@ export class Watcher {
   };
 
   private onReady = () => {
-    this.writeLog("onReady");
+    this.writeLog("Watcher ready");
   };
 
   public watchAndWait() {
@@ -80,7 +84,7 @@ export class Watcher {
         .on("ready", this.onReady);
     } catch (error) {
       this.writeLog("Error en watchAndWait");
-      console.error(error);
+      logger.error(error);
     }
   }
 }

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -3,6 +3,7 @@ import { Stats } from "fs";
 import { Logger } from "winston";
 
 import { QueueManager } from "@/queue/queue-manager";
+import { IQueueManager } from "@/queue/queueManager";
 
 import { OnAddDirService } from "./events/on-add-dir.service";
 import { OnAddService } from "./events/on-add.service";
@@ -18,7 +19,7 @@ export class Watcher {
   syncRootPath!: string;
   options!: Watcher.TOptions;
   virtualDriveFn!: IVirtualDriveFunctions;
-  queueManager!: QueueManager;
+  queueManager!: IQueueManager;
   logger!: Logger;
   fileInDevice = new Set<string>();
 

--- a/src/watcher/watcher.unit.test.ts
+++ b/src/watcher/watcher.unit.test.ts
@@ -3,12 +3,12 @@ import { existsSync } from "fs";
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { TEST_FILES } from "test/utils/setup.helper.test";
-import { sleep } from "test/utils/sleep.helper.test";
 import { v4 } from "uuid";
 import { beforeEach } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
 
 import { QueueManager } from "@/queue/queue-manager";
+import { sleep } from "@/utils";
 
 import { OnAddDirService } from "./events/on-add-dir.service";
 import { OnAddService } from "./events/on-add.service";

--- a/src/watcher/watcher.unit.test.ts
+++ b/src/watcher/watcher.unit.test.ts
@@ -6,6 +6,7 @@ import { TEST_FILES } from "test/utils/setup.helper.test";
 import { v4 } from "uuid";
 import { beforeEach } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
+import { Logger } from "winston";
 
 import { QueueManager } from "@/queue/queue-manager";
 import { sleep } from "@/utils";
@@ -20,7 +21,7 @@ import { IVirtualDriveFunctions } from "./watcher.interface";
 describe("Watcher", () => {
   const virtualDriveFn = mockDeep<IVirtualDriveFunctions>();
   const queueManager = mockDeep<QueueManager>();
-  const logPath = join(TEST_FILES, `${v4()}.log`);
+  const logger = mockDeep<Logger>();
   const options = {};
 
   const onAll = mockDeep<OnAllService>();
@@ -34,7 +35,7 @@ describe("Watcher", () => {
     }
 
     const watcher = new Watcher(onAll, onAdd, onAddDir, onRaw);
-    watcher.init(queueManager, syncRootPath, options, logPath, virtualDriveFn);
+    watcher.init(queueManager, syncRootPath, options, logger, virtualDriveFn);
     watcher.watchAndWait();
   };
 

--- a/test/utils/sleep.helper.test.ts
+++ b/test/utils/sleep.helper.test.ts
@@ -1,3 +1,0 @@
-export const sleep = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,12 +273,26 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
 
 "@esbuild/aix-ppc64@0.24.2":
   version "0.24.2"
@@ -923,6 +937,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -1064,11 +1083,6 @@ async@^3.2.3:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
-
-atomic-sleep@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
-  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -1292,6 +1306,13 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz#c0b29bcd33bcd0779a1344c2136051e6afd3d9e9"
   integrity sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==
 
+color-convert@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1299,15 +1320,39 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^2.0.7:
-  version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
-  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 commander@^9.0.0:
   version "9.5.0"
@@ -1350,11 +1395,6 @@ cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-dateformat@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
-  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.4.0:
   version "4.4.0"
@@ -1422,12 +1462,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1530,11 +1568,6 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-fast-copy@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
-  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
-
 fast-glob@^3.2.9:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
@@ -1551,16 +1584,6 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-redact@^3.1.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.5.0.tgz#e9ea02f7e57d0cd8438180083e93077e496285e4"
-  integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
-
-fast-safe-stringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
-  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
-
 fastq@^1.6.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.18.0.tgz#d631d7e25faffea81887fe5ea8c9010e1b36fee0"
@@ -1574,6 +1597,11 @@ fb-watchman@^2.0.0:
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
+
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -1596,6 +1624,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1695,11 +1728,6 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-help-me@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/help-me/-/help-me-5.0.0.tgz#b1ebe63b967b74060027c2ac61f9be12d354a6f6"
-  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
-
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -1741,7 +1769,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1750,6 +1778,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -2235,11 +2268,6 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-joycon@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
-  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2273,6 +2301,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -2304,6 +2337,18 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+logform@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.7.0.tgz#cfca97528ef290f2e125a08396805002b2d060d1"
+  integrity sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==
+  dependencies:
+    "@colors/colors" "1.6.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 loupe@^3.1.0, loupe@^3.1.2:
   version "3.1.2"
@@ -2385,7 +2430,7 @@ minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-ms@^2.1.3:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2443,17 +2488,19 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-on-exit-leak-free@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
-  integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
-
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.2:
   version "5.1.2"
@@ -2543,54 +2590,6 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pino-abstract-transport@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
-  integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
-  dependencies:
-    split2 "^4.0.0"
-
-pino-pretty@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-13.0.0.tgz#21d57fe940e34f2e279905d7dba2d7e2c4f9bf17"
-  integrity sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==
-  dependencies:
-    colorette "^2.0.7"
-    dateformat "^4.6.3"
-    fast-copy "^3.0.2"
-    fast-safe-stringify "^2.1.1"
-    help-me "^5.0.0"
-    joycon "^3.1.1"
-    minimist "^1.2.6"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^2.0.0"
-    pump "^3.0.0"
-    secure-json-parse "^2.4.0"
-    sonic-boom "^4.0.1"
-    strip-json-comments "^3.1.1"
-
-pino-std-serializers@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz#7c625038b13718dbbd84ab446bd673dc52259e3b"
-  integrity sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==
-
-pino@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-9.6.0.tgz#6bc628159ba0cc81806d286718903b7fc6b13169"
-  integrity sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==
-  dependencies:
-    atomic-sleep "^1.0.0"
-    fast-redact "^3.1.1"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^2.0.0"
-    pino-std-serializers "^7.0.0"
-    process-warning "^4.0.0"
-    quick-format-unescaped "^4.0.3"
-    real-require "^0.2.0"
-    safe-stable-stringify "^2.3.1"
-    sonic-boom "^4.0.1"
-    thread-stream "^3.0.0"
-
 pirates@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
@@ -2633,11 +2632,6 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-process-warning@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-4.0.1.tgz#5c1db66007c67c756e4e09eb170cdece15da32fb"
-  integrity sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==
-
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -2650,14 +2644,6 @@ pstree.remy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
-
-pump@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.2.tgz#836f3edd6bc2ee599256c924ffe0d88573ddcbf8"
-  integrity sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 pure-rand@^6.0.0:
   version "6.1.0"
@@ -2674,15 +2660,19 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-quick-format-unescaped@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
-  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
-
 react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+readable-stream@^3.4.0, readable-stream@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -2690,11 +2680,6 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
-
-real-require@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
-  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -2767,15 +2752,15 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-stable-stringify@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
-
-secure-json-parse@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
-  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -2809,6 +2794,13 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 simple-update-notifier@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
@@ -2825,13 +2817,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-sonic-boom@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
-  integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
-  dependencies:
-    atomic-sleep "^1.0.0"
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -2851,15 +2836,15 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-split2@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
-  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 stack-utils@^2.0.3:
   version "2.0.6"
@@ -2894,6 +2879,13 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -2957,12 +2949,10 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-thread-stream@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-3.1.0.tgz#4b2ef252a7c215064507d4ef70c05a5e2d34c4f1"
-  integrity sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==
-  dependencies:
-    real-require "^0.2.0"
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
 
 tinybench@^2.9.0:
   version "2.9.0"
@@ -3005,6 +2995,11 @@ touch@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.1.tgz#097a23d7b161476435e5c1344a95c0f75b4a5694"
   integrity sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==
+
+triple-beam@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 ts-essentials@>=10.0.0, ts-essentials@^10.0.2:
   version "10.0.4"
@@ -3108,6 +3103,11 @@ update-browserslist-db@^1.1.1:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 uuid@^11.0.3:
   version "11.0.5"
@@ -3213,6 +3213,32 @@ why-is-node-running@^2.3.0:
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
+
+winston-transport@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.9.0.tgz#3bba345de10297654ea6f33519424560003b3bf9"
+  integrity sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==
+  dependencies:
+    logform "^2.7.0"
+    readable-stream "^3.6.2"
+    triple-beam "^1.3.0"
+
+winston@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.17.0.tgz#74b8665ce9b4ea7b29d0922cfccf852a08a11423"
+  integrity sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==
+  dependencies:
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.7.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.9.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## What

Move from pino to winston and use the path from the virtual drive to the logger.

## Why

Pino was giving an error when used in drive-desktop (pino_1.default.transport is not a function). It was just happening with pino, so now winston is used.