### PR TITLE
[BUG] Fix disconnect addon sync root path

### DIFF
--- a/src/addon-wrapper.ts
+++ b/src/addon-wrapper.ts
@@ -13,19 +13,16 @@ export class Addon {
   }
 
   registerSyncRoot({
-    syncRootPath,
     providerName,
     providerVersion,
     providerId,
     logoPath,
   }: {
-    syncRootPath: string;
     providerName: string;
     providerVersion: string;
     providerId: string;
     logoPath: string;
   }) {
-    this.syncRootPath = syncRootPath;
     const result = addon.registerSyncRoot(this.syncRootPath, providerName, providerVersion, providerId, logoPath);
     return this.parseAddonZod("registerSyncRoot", result);
   }
@@ -41,7 +38,7 @@ export class Addon {
   }
 
   disconnectSyncRoot() {
-    addon.disconnectSyncRoot(this.syncRootPath);
+    return addon.disconnectSyncRoot(this.syncRootPath);
   }
 
   addLogger({ logPath }: { logPath: string }) {

--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -28,6 +28,7 @@ class VirtualDrive {
     };
 
     this.watcher = new Watcher();
+    addon.syncRootPath = syncRootPath;
 
     this.syncRootPath = syncRootPath;
     this.createSyncRootFolder();
@@ -190,7 +191,6 @@ class VirtualDrive {
   ): Promise<any> {
     this.callbacks = callbacks;
     return addon.registerSyncRoot({
-      syncRootPath: this.syncRootPath,
       providerName,
       providerVersion,
       providerId,
@@ -384,7 +384,7 @@ class VirtualDrive {
     }
   }
 
-  disconnectSyncRoot(): any {
+  disconnectSyncRoot() {
     return addon.disconnectSyncRoot();
   }
 


### PR DESCRIPTION
## What

Currently, the addon wrapper I've created in my last PR was setting the syncRootPath in the registerSyncRoot function. However, when we were disconnecting a drive without registering it first, the path was undefined, and it was stopping the execution.

## Fix

Set the addon syncRootPath in the virtual drive constructor.