### PR TITLE
Close file handler when creating placeholder

### DIFF
--- a/native-src/placeholders_interface/Planceholders.cpp
+++ b/native-src/placeholders_interface/Planceholders.cpp
@@ -265,6 +265,8 @@ bool Placeholders::ConvertToPlaceholder(const std::wstring &fullPath, const std:
             // Liberar el buffer de mensaje de error
             LocalFree(errorMsg);
 
+            CloseHandle(fileHandle);
+
             return false;
         }
 


### PR DESCRIPTION
## What

Fixes the bug of not being able of move folders.

## How

When we were creating placeholders, in case of an error in this creation, the handler of the file was never closed, so when we were trying to move the folder it was saying that another process had that folder still in use.