### PR TITLE
Addon Refactoring: Singleton and Static Method for Unregister

### DIFF
--- a/src/addon-wrapper.ts
+++ b/src/addon-wrapper.ts
@@ -138,3 +138,15 @@ export class Addon {
     return this.parseAddonZod("hydrateFile", result);
   }
 }
+
+export class DependencyInjectionAddonProvider {
+  private static _addon: Addon;
+
+  static get() {
+    if (DependencyInjectionAddonProvider._addon) return DependencyInjectionAddonProvider._addon;
+
+    DependencyInjectionAddonProvider._addon = new Addon();
+
+    return DependencyInjectionAddonProvider._addon;
+  }
+}

--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path, { join, win32 } from "path";
 import winston from "winston";
 
-import { Addon } from "./addon-wrapper";
+import { Addon, DependencyInjectionAddonProvider } from "./addon-wrapper";
 import { createLogger } from "./logger";
 import { QueueManager } from "./queue/queue-manager";
 import { Callbacks } from "./types/callbacks.type";
@@ -25,7 +25,7 @@ class VirtualDrive {
   addon: Addon;
 
   constructor(syncRootPath: string, providerId: string, loggerPath: string) {
-    this.addon = new Addon();
+    this.addon = DependencyInjectionAddonProvider.get();
     this.syncRootPath = this.convertToWindowsPath(syncRootPath);
     loggerPath = this.convertToWindowsPath(loggerPath);
     this.providerId = providerId;
@@ -164,8 +164,8 @@ class VirtualDrive {
     return this.addon.unregisterSyncRoot({ providerId: this.providerId });
   }
 
-  unRegisterSyncRootByProviderId({ providerId }: { providerId: string }) {
-    return this.addon.unregisterSyncRoot({ providerId });
+  static unRegisterSyncRootByProviderId({ providerId }: { providerId: string }) {
+    return DependencyInjectionAddonProvider.get().unregisterSyncRoot({ providerId });
   }
 
   watchAndWait(path: string, queueManager: QueueManager, loggerPath: string): void {


### PR DESCRIPTION
**This Pull Request introduces two main changes to improve the management and consistency of the addon: the creation of a singleton for the addon and the conversion of the unregister method to static.**

- Creation of a singleton for the addon:
  - A singleton pattern has been implemented for the addon. This ensures that only one instance of the addon exists throughout the application, facilitating state management and preventing potential conflicts.
- Conversion of the unregister method to static:
  - The unregister method, which used provider id for deregistration, has been converted to a static method. This allows for more direct and consistent access to the method, without the need for an addon instance.