### PR TITLE
Addition of getRegisteredSyncRoots Method to Addon and Exposure as Static Function

### DIFF
--- a/include/sync_root_interface/SyncRoot.h
+++ b/include/sync_root_interface/SyncRoot.h
@@ -3,6 +3,16 @@
 #include <cfapi.h>
 #include <Callbacks.h>
 #include "stdafx.h"
+#include <iostream>
+#include <vector>
+
+struct SyncRoots
+{
+    std::wstring id;
+    std::wstring path;
+    std::wstring displayName;
+    std::wstring version;
+};
 
 struct ItemInfo
 {
@@ -15,6 +25,7 @@ class SyncRoot
 {
 public:
     static HRESULT RegisterSyncRoot(const wchar_t *syncRootPath, const wchar_t *providerName, const wchar_t *providerVersion, const GUID &providerId, const wchar_t *logoPath);
+    static std::vector<SyncRoots> GetRegisteredSyncRoots();
     static HRESULT ConnectSyncRoot(const wchar_t *syncRootPath, InputSyncCallbacks syncCallbacks, napi_env env, CF_CONNECTION_KEY *connectionKey);
     static HRESULT DisconnectSyncRoot(const wchar_t *syncRootPath);
     static HRESULT UnregisterSyncRoot(const GUID &providerId);

--- a/include/virtual_drive/Wrappers.h
+++ b/include/virtual_drive/Wrappers.h
@@ -5,6 +5,7 @@
 napi_value CreatePlaceholderFile(napi_env env, napi_callback_info args);
 napi_value UnregisterSyncRootWrapper(napi_env env, napi_callback_info args);
 napi_value RegisterSyncRootWrapper(napi_env env, napi_callback_info args);
+napi_value GetRegisteredSyncRootsWrapper(napi_env env, napi_callback_info args);
 napi_value ConnectSyncRootWrapper(napi_env env, napi_callback_info args);
 napi_value CreateEntryWrapper(napi_env env, napi_callback_info args);
 napi_value DisconnectSyncRootWrapper(napi_env env, napi_callback_info args);

--- a/native-src/main.cpp
+++ b/native-src/main.cpp
@@ -57,6 +57,24 @@ napi_value init(napi_env env, napi_value exports)
     return nullptr;
   }
 
+  // GetRegisteredSyncRootsWrapper
+  napi_property_descriptor getRegisteredSyncRootsRootDesc = {
+      "getRegisteredSyncRoots",
+      nullptr,
+      GetRegisteredSyncRootsWrapper,
+      nullptr,
+      nullptr,
+      nullptr,
+      napi_default,
+      nullptr};
+
+  napi_status defineGetRegisteredSyncRootsRootDescStatus = napi_define_properties(env, exports, 1, &getRegisteredSyncRootsRootDesc);
+  if (defineGetRegisteredSyncRootsRootDescStatus != napi_ok)
+  {
+    napi_throw_error(env, nullptr, "Failed to define getRegisteredSyncRoots function");
+    return nullptr;
+  }
+
   // ConnectSyncRootWrapper
   napi_property_descriptor connectSyncRootDesc = {
       "connectSyncRoot",

--- a/native-src/sync_root_interface/SyncRoot.cpp
+++ b/native-src/sync_root_interface/SyncRoot.cpp
@@ -1,10 +1,10 @@
 #include "Callbacks.h"
 #include "SyncRoot.h"
 #include "stdafx.h"
-#include <iostream>
-#include <iostream>
 #include <filesystem>
 #include "Logger.h"
+#include <iostream>
+#include <vector>
 
 namespace fs = std::filesystem;
 // variable to disconect
@@ -168,6 +168,45 @@ HRESULT SyncRoot::RegisterSyncRoot(const wchar_t *syncRootPath, const wchar_t *p
         wprintf(L"Could not register the sync root, hr %08x\n", static_cast<HRESULT>(winrt::to_hresult()));
         return E_FAIL;
     }
+}
+
+std::vector<SyncRoots> SyncRoot::GetRegisteredSyncRoots()
+{
+    std::vector<SyncRoots> syncRootList;
+    try
+    {
+        auto syncRoots = winrt::StorageProviderSyncRootManager::GetCurrentSyncRoots();
+
+        printf("Sync roots count: %d\n", syncRoots.Size());
+
+        for (auto const &info : syncRoots)
+        {
+            auto contextBuffer = info.Context();
+            std::wstring contextString;
+            if (contextBuffer)
+            {
+                contextString = winrt::CryptographicBuffer::ConvertBinaryToString(
+                                    winrt::BinaryStringEncoding::Utf8,
+                                    contextBuffer)
+                                    .c_str();
+            }
+
+            if (contextString.find(L"->") != std::wstring::npos)
+            {
+                SyncRoots sr;
+                sr.id = info.Id();
+                sr.path = info.Path().Path();
+                sr.displayName = info.DisplayNameResource();
+                sr.version = info.Version();
+                syncRootList.push_back(sr);
+            }
+        }
+    }
+    catch (...)
+    {
+        Logger::getInstance().log("ERROR: getting sync root", LogLevel::INFO);
+    }
+    return syncRootList;
 }
 
 HRESULT SyncRoot::UnregisterSyncRoot(const GUID &providerId)

--- a/native-src/virtual_drive/Wrappers.cpp
+++ b/native-src/virtual_drive/Wrappers.cpp
@@ -5,6 +5,15 @@
 #include "LoggerPath.h"
 #include <Logger.h>
 #include <SyncRoot.h>
+#include <codecvt>
+#include <locale>
+#include <vector>
+
+std::string WStringToUTF8(const std::wstring &wstr)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+    return conv.to_bytes(wstr);
+}
 
 napi_value CreatePlaceholderFile(napi_env env, napi_callback_info args)
 {
@@ -200,6 +209,75 @@ napi_value RegisterSyncRootWrapper(napi_env env, napi_callback_info args)
     napi_value napiResult;
     napi_create_int32(env, static_cast<int32_t>(result), &napiResult);
     return napiResult;
+}
+
+napi_value GetRegisteredSyncRootsWrapper(napi_env env, napi_callback_info args)
+{
+    try
+    {
+        std::vector<SyncRoots> roots = SyncRoot::GetRegisteredSyncRoots();
+
+        napi_value jsArray;
+        napi_status status = napi_create_array_with_length(env, roots.size(), &jsArray);
+        if (status != napi_ok)
+            throw std::runtime_error("Error creando el array");
+
+        for (size_t i = 0; i < roots.size(); i++)
+        {
+            napi_value jsObj;
+            status = napi_create_object(env, &jsObj);
+            if (status != napi_ok)
+                throw std::runtime_error("Error creando el objeto");
+
+            std::string id = WStringToUTF8(roots[i].id);
+            napi_value napiId;
+            status = napi_create_string_utf8(env, id.c_str(), id.size(), &napiId);
+            if (status != napi_ok)
+                throw std::runtime_error("Error creando la cadena id");
+            napi_set_named_property(env, jsObj, "id", napiId);
+
+            // Propiedad "path"
+            std::string path = WStringToUTF8(roots[i].path);
+            napi_value napiPath;
+            status = napi_create_string_utf8(env, path.c_str(), path.size(), &napiPath);
+            if (status != napi_ok)
+                throw std::runtime_error("Error creando la cadena path");
+            napi_set_named_property(env, jsObj, "path", napiPath);
+
+            // Propiedad "displayName"
+            std::string displayName = WStringToUTF8(roots[i].displayName);
+            napi_value napiDisplayName;
+            status = napi_create_string_utf8(env, displayName.c_str(), displayName.size(), &napiDisplayName);
+            if (status != napi_ok)
+                throw std::runtime_error("Error creando la cadena displayName");
+            napi_set_named_property(env, jsObj, "displayName", napiDisplayName);
+
+            // Propiedad "version"
+            std::string version = WStringToUTF8(roots[i].version);
+            napi_value napiVersion;
+            status = napi_create_string_utf8(env, version.c_str(), version.size(), &napiVersion);
+            if (status != napi_ok)
+                throw std::runtime_error("Error creando la cadena version");
+            napi_set_named_property(env, jsObj, "version", napiVersion);
+
+            // Insertamos el objeto en el array
+            status = napi_set_element(env, jsArray, i, jsObj);
+            if (status != napi_ok)
+                throw std::runtime_error("Error insertando el elemento en el array");
+        }
+
+        return jsArray;
+    }
+    catch (const std::exception &ex)
+    {
+        napi_throw_error(env, nullptr, ex.what());
+        return nullptr;
+    }
+    catch (...)
+    {
+        napi_throw_error(env, nullptr, "An unknown error occurred in GetRegisteredSyncRootsWrapper");
+        return nullptr;
+    }
 }
 
 napi_value ConnectSyncRootWrapper(napi_env env, napi_callback_info args)

--- a/src/addon-wrapper.ts
+++ b/src/addon-wrapper.ts
@@ -27,6 +27,11 @@ export class Addon {
     return this.parseAddonZod("registerSyncRoot", result);
   }
 
+  getRegisteredSyncRoots() {
+    const result = addon.getRegisteredSyncRoots();
+    return this.parseAddonZod("getRegisteredSyncRoots", result);
+  }
+
   connectSyncRoot({ callbacks }: { callbacks: Callbacks }) {
     const result = addon.connectSyncRoot(this.syncRootPath, callbacks);
     return this.parseAddonZod("connectSyncRoot", result);

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -53,4 +53,5 @@ export type TAddon = {
    * TODO: Returns a type in c++ that is not initialized
    */
   updateFileIdentity(itemPath: string, id: string, isDirectory: boolean): any;
+  getRegisteredSyncRoots(): z.infer<typeof addonZod.getRegisteredSyncRoots>;
 };

--- a/src/addon/addon-zod.ts
+++ b/src/addon/addon-zod.ts
@@ -14,4 +14,12 @@ export const addonZod = {
   registerSyncRoot: z.literal(0),
   updateSyncStatus: z.boolean(),
   unregisterSyncRoot: z.number(),
+  getRegisteredSyncRoots: z.array(
+    z.object({
+      id: z.string(),
+      path: z.string(),
+      displayName: z.string(),
+      version: z.string(),
+    }),
+  ),
 };

--- a/src/virtual-drive.ts
+++ b/src/virtual-drive.ts
@@ -160,6 +160,10 @@ class VirtualDrive {
     });
   }
 
+  static async getRegisteredSyncRoots() {
+    return await DependencyInjectionAddonProvider.get().getRegisteredSyncRoots();
+  }
+
   unregisterSyncRoot() {
     return this.addon.unregisterSyncRoot({ providerId: this.providerId });
   }


### PR DESCRIPTION
This Pull Request introduces a new method in the addon to retrieve the registered synchronization root folders and exposes it as a static function to facilitate its use.

- Creation of the getRegisteredSyncRoots method:
  - The getRegisteredSyncRoots method has been implemented in the addon. This method allows retrieving a list of all synchronization root folders that are currently registered in the system.
- Exposure as a static function:
  - The getRegisteredSyncRoots method has been exposed as a static function. This allows accessing the method directly from the addon class, without the need to instantiate an addon object, which simplifies its use in different parts of the application.