### PR TITLE
Fix get register root

### DIFF
--- a/native-src/sync_root_interface/SyncRoot.cpp
+++ b/native-src/sync_root_interface/SyncRoot.cpp
@@ -146,7 +146,7 @@ HRESULT SyncRoot::RegisterSyncRoot(const wchar_t *syncRootPath, const wchar_t *p
 
         // Context
         std::wstring syncRootIdentity(syncRootPath);
-        syncRootIdentity.append(L"#intx#");
+        syncRootIdentity.append(L"#inxt#");
         syncRootIdentity.append(providerName);
 
         winrt::IBuffer contextBuffer = winrt::CryptographicBuffer::ConvertStringToBinary(syncRootIdentity.data(), winrt::BinaryStringEncoding::Utf8);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/node-win",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Drive desktop node addon",
   "main": "dist/index.ts",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This Pull Request corrects an error that was affecting the filtering of registered roots.

- Filtering error fix:
  - An error in the filtering logic used to obtain registered roots has been identified and corrected. This fix ensures that the list of registered roots is filtered correctly, showing only the relevant information.